### PR TITLE
Add basic login script and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,26 @@
 # Coursera-test
-coursera test
+
+This repository contains sample code.
+
+## User Login
+
+`login.py` provides a basic username/password login check using SHA-256 hashes.
+
+Run the script:
+
+```bash
+python3 login.py
+```
+
+Default credentials:
+- username: `admin`
+- password: `password123`
+
+## Tests
+
+Run tests with `pytest`:
+
+```bash
+pip install pytest
+python3 -m pytest
+```

--- a/login.py
+++ b/login.py
@@ -1,0 +1,26 @@
+import hashlib
+import getpass
+
+# Simple user database with SHA-256 hashed passwords
+USERS = {
+    'admin': 'ef92b778bafe771e89245b89ecbc08a44a4e166c06659911881f383d4473e94f'
+}
+
+def hash_password(password: str) -> str:
+    """Return the SHA-256 hash of the provided password."""
+    return hashlib.sha256(password.encode('utf-8')).hexdigest()
+
+
+def verify_login(username: str, password: str) -> bool:
+    """Verify if the username and password match the stored credentials."""
+    hashed = USERS.get(username)
+    return hashed == hash_password(password)
+
+
+if __name__ == '__main__':
+    username = input('Username: ')
+    password = getpass.getpass('Password: ')
+    if verify_login(username, password):
+        print('Login successful.')
+    else:
+        print('Invalid username or password.')

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -1,0 +1,10 @@
+import login
+
+def test_login_success():
+    assert login.verify_login('admin', 'password123')
+
+def test_login_fail_username():
+    assert not login.verify_login('unknown', 'password123')
+
+def test_login_fail_password():
+    assert not login.verify_login('admin', 'wrongpassword')


### PR DESCRIPTION
## Summary
- add `login.py` with simple password check using SHA-256
- document how to run the login script and tests in README
- add pytest tests covering success and failure cases

## Testing
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d0e04fa888333af5539cddd385fe1